### PR TITLE
validation için "distinct" dahil edildi

### DIFF
--- a/tr/validation.php
+++ b/tr/validation.php
@@ -34,6 +34,7 @@ return [
     'different'      => ':attribute ile :other birbirinden farklı olmalıdır.',
     'digits'         => ':attribute :digits rakam olmalıdır.',
     'digits_between' => ':attribute :min ile :max arasında rakam olmalıdır.',
+    'distinct'       => ':attribute tekrarlanan bir değere sahiptir.',
     'email'          => ':attribute doğru bir e-posta olmalıdır.',
     'filled'         => 'Seçili :attribute alanı doldurulmak zorundadır.',
     'exists'         => 'Seçili :attribute geçersiz.',


### PR DESCRIPTION
Yeni gelen array validation ile ilgili, "validasyon işlemi yapılan alanın tekrar eden herhangi bir değeri olmamalı" şeklinde bir açıklaması var. *( When working with arrays, the field under validation must not have any duplicate values. )*

Aşağıdaki iki alternatif tercümeyi düşündüm, ancak birincisini kullandım. İkisi birlikte de kullanılabilir.

1. ":attribute tekrarlanan bir değere sahiptir."
2. ":attribute yenilenen bir değere sahiptir."
3. ":attribute yenilenen/tekrarlanan bir değere sahiptir."


Kaynaklar

https://github.com/laravel/laravel/commit/c36799dddeaff2a0129b2dc2a18d34651463b9a8
https://laravel.com/docs/5.2/validation#rule-distinct