### PR TITLE
Laravel 5.4.3 güncellemesi ve hatalı after/before tarih düzeltmesi [5.4]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Laravel 5.3.x Türkçe dil dosyaları
+## Laravel 5.4.x Türkçe dil dosyaları
 
-> "[Laravel Türkiye](http://laravel.gen.tr/)" tarafından Laravel 5.3.x sürümleri için tercüme edilen ve geliştirilen Laravel Türkçe dil dosyalarıdır.
+> "[Laravel Türkiye](http://laravel.gen.tr/)" tarafından Laravel 5.4.x sürümleri için tercüme edilen ve geliştirilen Laravel Türkçe dil dosyalarıdır.
 
 
 ### Dil dosyası kurulumu

--- a/tr/validation.php
+++ b/tr/validation.php
@@ -15,12 +15,14 @@ return [
 
     'accepted'   => ':attribute kabul edilmelidir.',
     'active_url' => ':attribute geçerli bir URL olmalıdır.',
-    'after'      => ':attribute şundan daha eski bir tarih olmalıdır :date.',
+    'after'      => ':attribute değeri, :date tarihinden daha sonraki bir tarih olmalıdır.',
+    'after_or_equal' => ':attribute değeri, :date tarihinden daha sonraki veya aynı tarih olmalıdır.',
     'alpha'      => ':attribute sadece harflerden oluşmalıdır.',
     'alpha_dash' => ':attribute sadece harfler, rakamlar ve tirelerden oluşmalıdır.',
     'alpha_num'  => ':attribute sadece harfler ve rakamlar içermelidir.',
     'array'      => ':attribute dizi olmalıdır.',
     'before'     => ':attribute şundan daha önceki bir tarih olmalıdır :date.',
+    'before_or_equal' => ':attribute değeri, :date tarihinden daha önceki veya aynı tarih olmalıdır.',
     'between'    => [
         'numeric' => ':attribute :min - :max arasında olmalıdır.',
         'file'    => ':attribute :min - :max arasındaki kilobayt değeri olmalıdır.',

--- a/tr/validation.php
+++ b/tr/validation.php
@@ -21,7 +21,7 @@ return [
     'alpha_dash' => ':attribute sadece harfler, rakamlar ve tirelerden oluşmalıdır.',
     'alpha_num'  => ':attribute sadece harfler ve rakamlar içermelidir.',
     'array'      => ':attribute dizi olmalıdır.',
-    'before'     => ':attribute şundan daha önceki bir tarih olmalıdır :date.',
+    'before'     => ':attribute değeri, :date tarihinden daha önceki bir tarih olmalıdır.',
     'before_or_equal' => ':attribute değeri, :date tarihinden daha önceki veya aynı tarih olmalıdır.',
     'between'    => [
         'numeric' => ':attribute :min - :max arasında olmalıdır.',


### PR DESCRIPTION
- Dosyaları Laravel 5.4.3 sürümüne güncelledim, 5.4 ağacı açılabilir, master üzerinden.
- After/Before tarih doğrulamaları hatalıydı, düzelttim.